### PR TITLE
Waypoint Index Finder Efficiency

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -123,8 +123,8 @@ class WaypointUpdater(object):
             #        pass
             ##New loop - loops forward from previous waypoints unless there is no index orientation (first run, or can be utilized in reset)
             for i in len(self.base_waypoints):
-                refIndex = i + self.previous_reference_wp
-                if isInFront(self.current_pose.pose, self.base_waypoints[refIndex].pose.pose) and (refIndex < len(self.base_waypoints)):
+                refIndex = (i + self.previous_reference_wp) % len(self.base_waypoints)
+                if isInFront(self.current_pose.pose, self.base_waypoints[refIndex].pose.pose):
                     if self.waypoint_index_oriented:
                         index = refIndex
                         self.previous_reference_wp = refIndex

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -122,7 +122,7 @@ class WaypointUpdater(object):
             #    else:
             #        pass
             ##New loop - loops forward from previous waypoints unless there is no index orientation (first run, or can be utilized in reset)
-            for i in len(self.base_waypoints):
+            for i in range(len(self.base_waypoints)):
                 refIndex = (i + self.previous_reference_wp) % len(self.base_waypoints)
                 if isInFront(self.current_pose.pose, self.base_waypoints[refIndex].pose.pose):
                     if self.waypoint_index_oriented:


### PR DESCRIPTION
Example on how to increase list-iteration efficiency. Included old method for completely naive waypoint index location, but may not be needed.

DID NOT DEBUG/TEST, MAY NEED TO RE-ENUMERATE SELF.BASE_WAYPOINTS INSTEAD OF LEN()